### PR TITLE
Create correct column type for currency columns.

### DIFF
--- a/src/pgdbf.c
+++ b/src/pgdbf.c
@@ -592,7 +592,7 @@ int main(int argc, char **argv) {
             if(optusecreatetable) printf("TIMESTAMP");
             break;
         case 'Y':
-            if(optusecreatetable) printf("DECIMAL(4)");
+            if(optusecreatetable) printf("DECIMAL(20,4)");
             break;
         default:
             if(optusecreatetable) printf("\n");


### PR DESCRIPTION
If the Postgres DECIMAL type has only one modifier, it is the total
number of digits, not the scale (digits after the decimal point).
