### PR TITLE
Autoindex and simulated varchar fields

### DIFF
--- a/src/pgdbf.c
+++ b/src/pgdbf.c
@@ -338,7 +338,7 @@ int main(int argc, char **argv) {
         exitwitherror("Unable to read the entire DBF header", 1);
     }
 
-    if(dbfheader.signature == 0x30) {
+    if((dbfheader.signature == 0x30) || (dbfheader.signature == 0x31) || (dbfheader.signature == 0x32)) {
         /* Certain DBF files have an (empty?) 263-byte buffer after the header
          * information.  Take that into account when calculating field counts
          * and possibly seeking over it later. */
@@ -545,6 +545,7 @@ int main(int argc, char **argv) {
             if(optusecreatetable) printf("DOUBLE PRECISION");
             break;
         case 'C':
+        case 'V':
         case 'W':
             if(optusecreatetable) printf("VARCHAR(%d)", fields[fieldnum].length);
             break;


### PR DESCRIPTION
1.) Added the autoindex ( autoincrement ) field identifier 0x31 and 0x32, so the script does not crash if a FoxPro Table is set to autoindex.
2.) Added a switch condition for varchar fields, so that the script does not crash if the varchar field is simulated as a char field.
Stephan Kasdorf