### PR TITLE
Corrupted memos

### DIFF
--- a/doc/pgdbf.man
+++ b/doc/pgdbf.man
@@ -4,7 +4,7 @@ pgdbf \- convert XBase / FoxPro tables to PostgreSQL
 
 .SH SYNOPSIS
 .B pgdbf
-[\-cCdDeEhqQtTuU] [-m memofile] filename [indexcolumn ...]
+[\-cCdDeEhqQtTuU] [-w excesslength] [-m memofile] filename [indexcolumn ...]
 
 .SH DESCRIPTION
 PgDBF is a program for converting XBase databases - particularly FoxPro
@@ -156,6 +156,14 @@ statement to clear the contents of a table before copying data into it.
 Suppress the
 .B TRUNCATE TABLE
 statement. Default.
+.TP
+.B -w excesslength
+Warn of corrupted MEMO fields, by reporting errors on the output and through
+standard error. excesslenght specifies a MEMO length beyond which a MEMO record
+will be considered corrupt. A value of 0 (zero) will disable this heuristic,
+but the other warnings will still be issued (invalid start offset, invalid type,
+zero length and length beyond end of file). Conversion will not stop when warnings
+are issued.
 
 .SH "OPTION NOTES"
 The

--- a/src/pgdbf.h
+++ b/src/pgdbf.h
@@ -46,6 +46,9 @@
 #define NUMERICMEMOSTYLE 0
 #define PACKEDMEMOSTYLE 1
 
+#define MEMOTYPEPICTURE 0
+#define MEMOTYPETEXT 1
+
 /* Don't edit this! It's defined in the XBase specification. */
 #define XBASEFIELDNAMESIZE 11
 
@@ -244,6 +247,9 @@ static char* convertcharset(const char* inputstring, size_t* inputsize)
 #endif
 
 static void exitwitherror(const char *message, const int systemerror) {
+    /* Flush the standard output in case data is still buffered */
+    fflush(stdout);
+
     /* Print the given error message to stderr, then exit.  If systemerror
      * is true, then use perror to explain the value in errno. */
     if(systemerror) {


### PR DESCRIPTION
More robust handling of MEMO records, and ability to detect corrupt
MEMO data and report it on the output and stderr.

pgdbf was crashing on me due to a mismatched dbf/fpt combo.
    Added code to prevent calling safeprintbuf with a memo length
        that in combination with the memo start offset, exceeds
        the memo file length.

Usage:

-w excesslength

Warn of corrupted MEMO fields, by reporting errors on the output and through
standard error. excesslenght specifies a MEMO length beyond which a MEMO record
will be considered corrupt. A value of 0 (zero) will disable this heuristic,
but the other warnings will still be issued (invalid start offset, invalid type,
zero length and length beyond end of file). Conversion will not stop when warnings
are issued.

Also: 

src/pgdbf.h:exitwitherror: Flush the standard output in case data is still buffered.
        Some processed output was being left out if the program crashed or exit.

